### PR TITLE
-t option changes aci target directory's home

### DIFF
--- a/builder/aci.go
+++ b/builder/aci.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ghodss/yaml"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -121,15 +122,15 @@ func NewAci(path string, args BuildArgs) (*Img, error) {
 	return NewAciWithManifest(path, args, *manifest)
 }
 
-func PrepAci(path string, args BuildArgs) (*Img, error) {
+func PrepAci(aciPath string, args BuildArgs) (*Img, error) {
 	cnt := new(Img)
 	cnt.args = args
 
-	if fullPath, err := filepath.Abs(path); err != nil {
+	if fullPath, err := filepath.Abs(aciPath); err != nil {
 		log.Get().Panic("Cannot get fullpath of project", err)
 	} else {
 		cnt.path = fullPath
-		cnt.target = cnt.path + "/target"
+		cnt.target = path.Join(args.TargetPath, "target")
 		cnt.rootfs = cnt.target + "/rootfs"
 	}
 	return cnt, nil

--- a/builder/build.go
+++ b/builder/build.go
@@ -5,6 +5,7 @@ type BuildArgs struct {
 	Clean       bool
 	ForceUpdate bool
 	Path        string
+	TargetPath  string
 }
 
 type BuildError struct {

--- a/commands/cnt.go
+++ b/commands/cnt.go
@@ -16,8 +16,9 @@ func Execute() {
 	var rootCmd = &cobra.Command{Use: "cnt"}
 	buildCmd.Flags().BoolVarP(&buildArgs.Zip, "nozip", "z", false, "Zip final image or not")
 	rootCmd.PersistentFlags().BoolVarP(&buildArgs.Clean, "clean", "c", false, "Clean before doing anything")
+	rootCmd.PersistentFlags().StringVarP(&buildArgs.TargetPath, "target-path", "t", ".", "Set target path")
 
-	rootCmd.AddCommand(buildCmd, cleanCmd, pushCmd, installCmd, testCmd, versionCmd, initCmd,updateCmd)
+	rootCmd.AddCommand(buildCmd, cleanCmd, pushCmd, installCmd, testCmd, versionCmd, initCmd, updateCmd)
 
 	config.GetConfig().Load()
 	rootCmd.Execute()


### PR DESCRIPTION
With this change you can run any cnt aci command against a target directory out of your work directory.

Example : 

    cnt -t /tmp clean
    cnt -t /tmp build

will work on a /tmp/target directory.