### PR TITLE
Chmod if file exist and is not executable

### DIFF
--- a/builder/aci.go
+++ b/builder/aci.go
@@ -16,8 +16,10 @@ execute_files() {
   fdir=$1
   [ -d "$fdir" ] || return 0
 
-  for file in $fdir/*; do
-    [ -x "$file" ] || /cnt/bin/busybox chmod +x "$file"
+  for file in $fdir; do
+    [ -e "$file" ] && {
+     [ -x "$file" ] || /cnt/bin/busybox chmod +x "$file"
+    }
     echo -e "\e[1m\e[32mRunning script -> $file\e[0m"
     $file
   done


### PR DESCRIPTION
![That Prove Babies And Kittens Are Not Cute Together](http://i.imgur.com/rO8ZAOP.gif)

I would have love a one liner like 
`[ -e "$file" ] && [ -x "$file" ] || /cnt/bin/busybox chmod +x "$file"``
But the condition doesn't seems to be taken in the proper order.