### PR TITLE
CWD_template

### DIFF
--- a/builder/aci-test.go
+++ b/builder/aci-test.go
@@ -17,8 +17,12 @@ const STATUS_SUFFIX = "_status"
 const TEST_INIT_SCRIPT = `#!/bin/bash
 set -x
 
-%%COMMAND%% &
+[ -d %%CWD%% ] && {
+	cd %%CWD%%
+}
 
+%%COMMAND%% &
+cd /
 waitsuccess="0"
 if [ -f "/tests/wait.sh" ]; then
 	chmod +x /tests/wait.sh
@@ -139,7 +143,9 @@ func (cnt *Img) prepareTestAci() (*Img, error) {
 		}
 	}
 
+
 	ExecScript := strings.Replace(TEST_INIT_SCRIPT, "%%COMMAND%%", "'"+strings.Join(cnt.manifest.Aci.App.Exec, "' '")+"'", 1)
+	ExecScript = strings.Replace(ExecScript, "%%CWD%%", "'" + cnt.manifest.Aci.App.WorkingDirectory + "'", 2)
 
 	ioutil.WriteFile(cnt.target+PATH_TESTS+PATH_FILES+"/init.sh", []byte(ExecScript), 0777)
 


### PR DESCRIPTION
Fix the tests where the Exec has a different CWD as specified in the manifest.

![-_-](http://i.imgur.com/iVo13IS.gif)