### PR TITLE
Replace deprecated --insecure-skip-verify with new --insecure-options

### DIFF
--- a/builder/aci-build.go
+++ b/builder/aci-build.go
@@ -116,7 +116,7 @@ func (cnt *Aci) processFrom() {
 		return
 	}
 	if err := utils.ExecCmd("bash", "-c", "rkt image list --fields name --no-legend | grep -q "+cnt.manifest.From.String()); err != nil {
-		utils.ExecCmd("rkt", "--insecure-skip-verify=true", "fetch", cnt.manifest.From.String())
+		utils.ExecCmd("rkt", "--insecure-options=tls", "fetch", cnt.manifest.From.String())
 	}
 	if err := utils.ExecCmd("rkt", "image", "render", "--overwrite", cnt.manifest.From.String(), cnt.target); err != nil {
 		panic("Cannot render from image" + cnt.manifest.From.String() + err.Error())

--- a/builder/aci-build.go
+++ b/builder/aci-build.go
@@ -116,7 +116,7 @@ func (cnt *Aci) processFrom() {
 		return
 	}
 	if err := utils.ExecCmd("bash", "-c", "rkt image list --fields name --no-legend | grep -q "+cnt.manifest.From.String()); err != nil {
-		utils.ExecCmd("rkt", "--insecure-options=tls", "fetch", cnt.manifest.From.String())
+		utils.ExecCmd("rkt", "--insecure-options=image", "fetch", cnt.manifest.From.String())
 	}
 	if err := utils.ExecCmd("rkt", "image", "render", "--overwrite", cnt.manifest.From.String(), cnt.target); err != nil {
 		panic("Cannot render from image" + cnt.manifest.From.String() + err.Error())

--- a/builder/aci-install.go
+++ b/builder/aci-install.go
@@ -13,7 +13,7 @@ func (aci *Aci) Install() string {
 		aci.Test()
 	}
 	os.Remove(aci.target + PATH_INSTALLED)
-	hash, err := utils.ExecCmdGetOutput("rkt", "--insecure-skip-verify=true", "fetch", aci.target+PATH_IMAGE_ACI)
+	hash, err := utils.ExecCmdGetOutput("rkt", "--insecure-options=tls", "fetch", aci.target+PATH_IMAGE_ACI)
 	if err != nil {
 		panic("Cannot install" + err.Error())
 	}

--- a/builder/aci-install.go
+++ b/builder/aci-install.go
@@ -13,7 +13,7 @@ func (aci *Aci) Install() string {
 		aci.Test()
 	}
 	os.Remove(aci.target + PATH_INSTALLED)
-	hash, err := utils.ExecCmdGetOutput("rkt", "--insecure-options=tls", "fetch", aci.target+PATH_IMAGE_ACI)
+	hash, err := utils.ExecCmdGetOutput("rkt", "--insecure-options=image", "fetch", aci.target+PATH_IMAGE_ACI)
 	if err != nil {
 		panic("Cannot install" + err.Error())
 	}

--- a/builder/aci-test.go
+++ b/builder/aci-test.go
@@ -70,7 +70,7 @@ func (cnt *Aci) Test() {
 	os.MkdirAll(cnt.target+PATH_TESTS+PATH_TARGET+PATH_RESULT, 0777)
 
 	if err := utils.ExecCmd("rkt",
-		"--insecure-skip-verify=true",
+		"--insecure-options=tls",
 		"run",
 		"--net=host",
 		"--mds-register=false",
@@ -119,7 +119,7 @@ func (cnt *Aci) importAciBats() {
 		if err := ioutil.WriteFile("/tmp/aci-bats.aci", content, 0644); err != nil {
 			panic(err)
 		}
-		utils.ExecCmd("rkt", "--insecure-skip-verify=true", "fetch", "/tmp/aci-bats.aci")
+		utils.ExecCmd("rkt", "--insecure-options=tls", "fetch", "/tmp/aci-bats.aci")
 		os.Remove("/tmp/aci-bats.aci")
 	}
 }

--- a/builder/aci-test.go
+++ b/builder/aci-test.go
@@ -70,7 +70,7 @@ func (cnt *Aci) Test() {
 	os.MkdirAll(cnt.target+PATH_TESTS+PATH_TARGET+PATH_RESULT, 0777)
 
 	if err := utils.ExecCmd("rkt",
-		"--insecure-options=tls",
+		"--insecure-options=image",
 		"run",
 		"--net=host",
 		"--mds-register=false",
@@ -119,7 +119,7 @@ func (cnt *Aci) importAciBats() {
 		if err := ioutil.WriteFile("/tmp/aci-bats.aci", content, 0644); err != nil {
 			panic(err)
 		}
-		utils.ExecCmd("rkt", "--insecure-options=tls", "fetch", "/tmp/aci-bats.aci")
+		utils.ExecCmd("rkt", "--insecure-options=image", "fetch", "/tmp/aci-bats.aci")
 		os.Remove("/tmp/aci-bats.aci")
 	}
 }

--- a/builder/pod-build.go
+++ b/builder/pod-build.go
@@ -110,7 +110,7 @@ Description={{ .Shortname }} %i
 
 [Service]
 ExecStartPre=/opt/bin/rkt gc --grace-period=0s --expire-prepared=0s
-ExecStart=/opt/bin/rkt --insecure-options=tls run \
+ExecStart=/opt/bin/rkt --insecure-options=image run \
 {{range $i, $e := .Commands}}  {{$e}} \
 {{end}}{{range $i, $e := .Acilist}}{{if $i}} \
 {{end}}  {{$e}}{{end}}

--- a/builder/pod-build.go
+++ b/builder/pod-build.go
@@ -110,7 +110,7 @@ Description={{ .Shortname }} %i
 
 [Service]
 ExecStartPre=/opt/bin/rkt gc --grace-period=0s --expire-prepared=0s
-ExecStart=/opt/bin/rkt --insecure-skip-verify run \
+ExecStart=/opt/bin/rkt --insecure-options=tls run \
 {{range $i, $e := .Commands}}  {{$e}} \
 {{end}}{{range $i, $e := .Acilist}}{{if $i}} \
 {{end}}  {{$e}}{{end}}

--- a/commands/cnt.go
+++ b/commands/cnt.go
@@ -15,7 +15,7 @@ import (
 
 var buildArgs = builder.BuildArgs{}
 
-const RKT_SUPPORTED_VERSION = "0.11.0"
+const RKT_SUPPORTED_VERSION = "0.12.0"
 
 func Execute() {
 	checkRktVersion()


### PR DESCRIPTION
```
--insecure-options=none
comma-separated list of security features to disable.
Allowed values: "none", "image", "tls", "ondisk", "all"
```