### PR TITLE
Add --force flag to init command, if path is not empty

### DIFF
--- a/commands/cnt.go
+++ b/commands/cnt.go
@@ -19,7 +19,6 @@ var buildArgs = builder.BuildArgs{}
 const RKT_SUPPORTED_VERSION = "0.12.0"
 
 var workPath string
-var initForce bool
 
 func Execute() {
 	checkRktVersion()
@@ -35,7 +34,6 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "loglevel", "L", "info", "Set log level")
 	rootCmd.PersistentFlags().StringVarP(&homePath, "home-path", "H", cnt.DefaultHomeFolder(), "Set home folder")
 	rootCmd.PersistentFlags().StringVarP(&workPath, "work-path", "W", ".", "Set the work path")
-	rootCmd.PersistentFlags().BoolVarP(&initForce, "force", "f", false, "Force init command if path is not empty")
 
 	rootCmd.AddCommand(buildCmd, cleanCmd, pushCmd, installCmd, testCmd, versionCmd, initCmd /*updateCmd,*/, graphCmd, aciVersion)
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {

--- a/commands/cnt.go
+++ b/commands/cnt.go
@@ -19,6 +19,7 @@ var buildArgs = builder.BuildArgs{}
 const RKT_SUPPORTED_VERSION = "0.12.0"
 
 var workPath string
+var initForce bool
 
 func Execute() {
 	checkRktVersion()
@@ -34,6 +35,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "loglevel", "L", "info", "Set log level")
 	rootCmd.PersistentFlags().StringVarP(&homePath, "home-path", "H", cnt.DefaultHomeFolder(), "Set home folder")
 	rootCmd.PersistentFlags().StringVarP(&workPath, "work-path", "W", ".", "Set the work path")
+	rootCmd.PersistentFlags().BoolVarP(&initForce, "force", "f", false, "Force init command if path is not empty")
 
 	rootCmd.AddCommand(buildCmd, cleanCmd, pushCmd, installCmd, testCmd, versionCmd, initCmd /*updateCmd,*/, graphCmd, aciVersion)
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {

--- a/commands/command-init.go
+++ b/commands/command-init.go
@@ -32,8 +32,10 @@ func discoverAndRunInitType(path string, args builder.BuildArgs) {
 	if err != nil {
 		logs.WithEF(err, fields).Fatal("Cannot read path directory")
 	}
-	if !empty {
-		logs.WithEF(err, fields).Fatal("Path is not empty cannot init")
+	if !initForce {
+		if !empty {
+			logs.WithEF(err, fields).Fatal("Path is not empty cannot init")
+		}
 	}
 
 	logs.WithEF(err, fields).Info("Init project")

--- a/commands/command-init.go
+++ b/commands/command-init.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 )
 
+var initForce bool
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "init files-tree",

--- a/commands/command.go
+++ b/commands/command.go
@@ -114,5 +114,7 @@ func init() {
 	pushCmd.Flags().BoolVarP(&buildArgs.NoTestFail, "no-test-fail", "T", false, "Fail if no tests found")
 	pushCmd.Flags().BoolVarP(&buildArgs.Test, "test", "t", false, "Run tests before push")
 
+	initCmd.Flags().BoolVarP(&initForce, "force", "f", false, "Force init command if path is not empty")
+
 	testCmd.Flags().BoolVarP(&buildArgs.NoTestFail, "no-test-fail", "T", false, "Fail if no tests found")
 }


### PR DESCRIPTION
Hi,
If I already had an aci folder with only a .git/ directory I can't `init` my directory coz is considered not empty...force's flag permits to initiate the aci folder regardless